### PR TITLE
Fix error when this.ref equals to null on edge 15

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ export default class EscapeOutside extends Component {
   }
 
   onClick(e) {
-    if (!this.ref.contains(e.target)) this.props.onEscapeOutside(e)
+    if (this.ref && !this.ref.contains(e.target)) this.props.onEscapeOutside(e)
   }
 
   getRef(ref) {


### PR DESCRIPTION
Added defensive code, before ```!this.ref.contains(e.target))``` to prevent call ```.includes()``` if ```this.ref``` is null.
@amytych check this one, please